### PR TITLE
Use simplified config check API + add OS env prefix

### DIFF
--- a/src/aeplugin_dev_mode_app.erl
+++ b/src/aeplugin_dev_mode_app.erl
@@ -9,7 +9,7 @@
 
 -define(PLUGIN_NAME_STR, <<"aeplugin_dev_mode">>).
 -define(SCHEMA_FNAME, "aeplugin_dev_mode_config_schema.json").
--define(OS_ENV_PFX, "DEV").
+-define(OS_ENV_PFX, "DEVMODE").
 
 start(_Type, _Args) ->
     {ok, Pid} = aeplugin_dev_mode_sup:start_link(),


### PR DESCRIPTION
This PR addresses the need to be able to parameterize a plugin running in a docker instance.
The PR relies on the PR aeternity/aeternity#3722