### PR TITLE
Add rollback support

### DIFF
--- a/src/aeplugin_dev_mode.app.src
+++ b/src/aeplugin_dev_mode.app.src
@@ -16,7 +16,7 @@
     {'$app_ctrl',
      [{modify,
        [
-        {roles, [{dev, [join]}]}
+        {roles, [{basic, [join]}]}
        ]}
      ]}
    ]},

--- a/src/aeplugin_dev_mode_handler.erl
+++ b/src/aeplugin_dev_mode_handler.erl
@@ -1,3 +1,4 @@
+%% -*- erlang-indent-level: 4; indent-tabs-mode: nil -*-
 -module(aeplugin_dev_mode_handler).
 
 -export([routes/0]).
@@ -6,8 +7,6 @@
         , content_types_provided/2
         , index_html/2
         , json_api/2
-        %% , emit_keyblocks/2
-        %% , emit_microblock/2
         ]).
 
 -import(aeplugin_dev_mode_html, [html/1, meta/0]).
@@ -22,7 +21,7 @@ routes() ->
            , {"/auto_emit_mb/", ?MODULE, []}
            , {"/spend", ?MODULE, []}
            , {"/status", ?MODULE, []}
-	   , {"/rollback", ?MODULE, []}
+           , {"/rollback", ?MODULE, []}
            ]}
     ].
 
@@ -38,14 +37,15 @@ content_types_provided(Req, State) ->
      ], Req#{'$result' => Result}, State}.
 
 json_api(#{'$result' := Result, qs := Qs} = Req, State) ->
-    Response = case Result of
-                   ok ->
-                       #{ <<"result">> => <<"ok">> };
-                   {error, Reason} ->
-                       #{ <<"error">> => to_bin(Reason)};
-                   Map when is_map(Map) ->
-                       Map
-               end,
+    Response0 = case Result of
+                    ok ->
+                        #{ <<"result">> => <<"ok">> };
+                    {error, Reason} ->
+                        #{ <<"error">> => to_bin(Reason)};
+                    Map when is_map(Map) ->
+                        Map
+                end,
+    Response = chain_status(Response0),
     JSON = parse_qs(Qs, [{<<"pp_json">>, boolean, false}],
                     fun(false) ->
                             jsx:encode(Response);
@@ -73,8 +73,8 @@ index_html(Req, State) ->
                  set_mb_interval_form(),
                  auto_emit_mb_form(),
                  spend_form(),
-		 {h4, <<"Rollback">>},
-		 rollback_form(),
+                 {h4, <<"Rollback">>},
+                 rollback_form(),
                  {hr, []},
                  {h3, <<"Chain:">>},
                  {p, [<<"Top height: ">>, integer_to_binary(aec_chain:top_height())]},
@@ -178,10 +178,9 @@ maybe_strong(false, Text) -> Text.
 
 serve_request(#{path := <<"/emit_kb">>, qs := Qs}) ->
     Params = httpd:parse_query(Qs),
-    N = case proplists:get_value(<<"n">>, Params, undefined) of
-            undefined ->
-                %% ignore
-                0;
+    OldHeight = aec_chain:top_height(),
+    N = case proplists:get_value(<<"n">>, Params, 1) of
+            1 -> 1;
             NStr ->
                 try binary_to_integer(NStr)
                 catch
@@ -192,7 +191,8 @@ serve_request(#{path := <<"/emit_kb">>, qs := Qs}) ->
         0 -> ok;
         _ ->
             aeplugin_dev_mode_emitter:emit_keyblocks(N)
-    end;
+    end,
+    #{<<"old_height">> => OldHeight};
 serve_request(#{path := <<"/kb_interval">>, qs := Qs}) ->
     parse_qs(Qs, [{<<"secs">>, integer, undefined}],
              fun(undefined) ->
@@ -258,27 +258,30 @@ serve_request(#{path := <<"/status">>}) ->
       <<"chain">> =>
           #{
             <<"top_height">> => aec_chain:top_height(),
+            <<"top_hash">> => encoded_top_hash(),
             <<"mempool_height">> => aec_tx_pool:size(),
             <<"all_balances">> => balances_json()
            },
       <<"accounts">> => devmode_accounts()
      };
 serve_request(#{path := <<"/rollback">>, qs := Qs}) ->
+    OldHeight = aec_chain:top_height(),
+    OldHash = encoded_top_hash(),
     Params = httpd:parse_query(Qs),
-    io:fwrite("Params = ~p~n", [Params]),
     [H, B] = [proplists:get_value(K, Params, <<>>)
-	      || K <- [<<"height">>, <<"hash">>]],
+              || K <- [<<"height">>, <<"hash">>]],
     {ok, [[Root]]} = init:get_argument(root),
     Script = filename:join(Root, "bin/aeternity db_rollback"),
     Cmd = binary_to_list(
-	    iolist_to_binary(
-	      [Script,
-	       [[" -h ", H] || H =/= <<>> ],
-	       [[" -b ", B] || B =/= <<>> ]])),
-    io:fwrite("Cmd = ~p~n", [Cmd]),
+            iolist_to_binary(
+              [Script,
+               [[" -h ", H] || H =/= <<>> ],
+               [[" -b ", B] || B =/= <<>> ]])),
+    lager:debug("Cmd = ~p~n", [Cmd]),
     Res = os:cmd(Cmd),
-    io:fwrite(">> ~s~n", [Res]),
-    ok;
+    lager:debug(">> ~s~n", [Res]),
+    #{ <<"old_height">> => OldHeight
+     , <<"old_top">> => OldHash };
 serve_request(_) ->
     ok.
 
@@ -387,3 +390,23 @@ to_bin(A) when is_atom(A) ->
     atom_to_binary(A, utf8);
 to_bin(X) ->
     iolist_to_binary(io_lib:fwrite("~p", [X])).
+
+chain_status(#{<<"chain">> := _} = Res) ->
+    Res;
+chain_status(Res) ->
+    TopHdr = aec_chain:top_header(),
+    Height = aec_headers:height(TopHdr),
+    Res#{ <<"chain">> => #{ <<"height">> => Height
+                          , <<"top_hash">> => encoded_top_hash(TopHdr) }}.
+
+encoded_top_hash() ->
+    TopHdr = aec_chain:top_header(),
+    encoded_top_hash(TopHdr).
+
+encoded_top_hash(TopHdr) ->
+    {ok, TopHash} = aec_headers:hash_header(TopHdr),
+    Type = case aec_headers:type(TopHdr) of
+               key   -> key_block_hash;
+               micro -> micro_block_hash
+           end,
+    aeser_api_encoder:encode(Type, TopHash).


### PR DESCRIPTION
This PR adds a `rollback` endpoint to the plugin. It also expands on the JSON return data, always reporting the current chain state (height, top hash).

In order to support rollback smoothly, the `aeplugin_dev_mode` app was moved to the `basic` role (see `app_ctrl`).
This way, the dev_mode plugin will always be running once it's activated.