### PR TITLE
No timeout on keyblock emission request

### DIFF
--- a/src/aeplugin_dev_mode_emitter.erl
+++ b/src/aeplugin_dev_mode_emitter.erl
@@ -39,7 +39,7 @@ start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
 emit_keyblocks(N) when is_integer(N), N > 0 ->
-    gen_server:call(?MODULE, {emit_keyblocks, N}).
+    gen_server:call(?MODULE, {emit_keyblocks, N}, infinity).
 
 set_prefilled_accounts_info(Accs) ->
     gen_server:call(?MODULE, {set_prefilled_accounts_info, Accs}).


### PR DESCRIPTION
See issue #24 

Normally, the plugin will automatically use the node's built-in emitter. The same fix is applied there via aeternity/aeternity#4164

This PR is sponsored by the ACF