### PR TITLE
Modified schema and logic for prefunded accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,8 +254,17 @@ docker build -t devmode .
 Running the above image:
 
 ```
-docker run -t devmode:latest -p 3313:3313
+docker run -t -p 3313:3313 devmode:latest
 ```
 
 Consult tutorials and documentation on Docker features. Specifically here, you need to use the
 `-p` opition to map the HTTP port (default: `3313`) so you can access the REST interface.
+
+You can feed configuration data into the docker container using OS environment variables:
+
+```
+docker run -t -p 3313:3313 -e "DEVMODE__PREFUNDED__GEN={\"quantity\":10, \"balance\":100000}" devmode:latest
+```
+
+(NOTE that this is similar to setting config data for the Aeternity node using the `AE__` prefix.
+The corresponding prefix for the dev mode plugin is `DEVMODE__`.)

--- a/README.md
+++ b/README.md
@@ -109,12 +109,14 @@ The default is `""` - i.e. no subdirectory.
 | prefunded:gen  | balance           | integer         |
 | prefunded:gen  | mnemonic          | string          |
 
-When the dev_mode plugin is initialized, and if it finds that there isn't yet
-a database in place (no chain has been created), it looks for a prefunded accounts file
+When the dev_mode plugin is initialized, it looks for a prefunded accounts file
 either specified with the plugin config `prefunded:file`, or as
 `WorkSpacePath[/WorkspaceName]/devmode_prefunded_accounts.json`.
 If there is no such file, it checks if parameters are provided for automatically
-generating accounts.
+generating accounts. Generation can only proceed if there isn't aleady a genesis
+block (the database has not yet been created). If there is no specified prefunded
+accounts file, and the chain exists, startup proceeds as normal. This would be the
+case when starting in dev mode based on an existing chain.
 
 #### Using multiple workspaces
 

--- a/README.md
+++ b/README.md
@@ -25,29 +25,30 @@ in Aeternity is not run. This is for development and testing only.
 
 ## Building
 
-The basic plugin uses some components that the Aeternity source depends on.
-To ensure that the same versions are used, check out the Aeternity source
-from [github](https://github.com/aeternity/aeternity), then set the OS
-environment variable `AE_ROOT` to point to the top `aeternity/` directory.
-The `rebar.config.script` logic in `aeplugin_dev_mode` will then fetch
-the correct versions for all dependencies listed with only the component
-name, e.g. `{deps, [lager, cowboy]}`.
+The plugin uses the `aeplugin_rebar3` rebar plugin. This collects
+dependencies from https://github.com/aeternity/aeternity (master).
+If you want to build against another version of Aeternity, checkout the
+[README for aeplugin_rebar3](https://github.com/aeplugin_rebar3).
 
-Example:
+Dependencies that are already part of the Aeternity node are given on the
+form `{lager, {ae, lager}}`. Other dependencies are declared as usual.
+
+To simply compile the code:
 ```
-$ export AE_ROOT=~/dev/aeternity
 $ rebar3 compile
 ```
 
-Note that (for now), the compiled code ends up under `_build/default/lib/`,
-so you can symlink or copy `_build/default/lib/aeplugin_dev_mode` into the
-Aeternity plugin lib root (see below).
+To build a plugin archive (will also compile), run the following command:
+
+```
+$ rebar3 ae_plugin
+```
+
+This should cause generation of a file `_build/default/aeplugin_dev_mode.ez`.
+This file is then copied or symlinked into the `AETERNITY_ROOT/plugins/` directory.
 
 ## Loading
 
-After compiling, copy or link the application directory found at
-`_build/default/lib/aeplugin_dev_mode` into the AE node's plugin lib
-root. If not otherwise configured, this defaults to `$AETERNITY_TOP/plugins/`.
 After this, the node can be started either with a configuration as suggested
 below, or most simply by providing some OS environment variables, for example:
 
@@ -87,6 +88,85 @@ dev_mode:
 options were given in the plugin config. They have now been moved to the Aeternity node
 config.
 
+### Plugin configuration options
+
+#### `workspace_path` (string)
+This makes it possible to specify a custom path to where the plugin can
+read and write files. The directiory must be read/write accessible.
+The default path is `AETERNITY_ROOT/data/aeplugin_dev_mode/`.
+
+### `workspace_name` (string)
+This specifies an optional subdirectory under the workspace path.
+The default is `""` - i.e. no subdirectory.
+
+### Prefunded accounts settings
+
+| group          | key               | type            |
+| ---------------|-------------------|-----------------|
+| prefunded      | file              | string          |
+| prefunded      | gen               | object          |
+| prefunded:gen  | quantity          | integer         |
+| prefunded:gen  | balance           | integer         |
+| prefunded:gen  | mnemonic          | string          |
+
+When the dev_mode plugin is initialized, and if it finds that there isn't yet
+a database in place (no chain has been created), it looks for a prefunded accounts file
+either specified with the plugin config `prefunded:file`, or as
+`WorkSpacePath[/WorkspaceName]/devmode_prefunded_accounts.json`.
+If there is no such file, it checks if parameters are provided for automatically
+generating accounts.
+
+#### Using multiple workspaces
+
+Here is an example aeternity config, which initializes a workspace, also placing
+the chain database in that workspace directory:
+
+```
+chain:
+  db_path: data/aeplugin_dev_mode/ws1
+system:
+  dev_mode: true
+  plugins:
+      -
+        name: aeplugin_dev_mode
+        config:
+          workspace_name: ws1
+          prefunded:
+            gen:
+              quantity: 10
+              balance: 1000000
+```
+The default workspace path of `AE_ROOT/data/aeplugin_dev_mode` is assumed.
+Note that if another workspace path is defined in the plugin config, the
+`chain:db_path` value needs to be modified to match. The node will expand
+all path strings to absolute paths from `AE_ROOT`. It will also create intermediate
+directories if possible, and ensure that the user has write access to the target
+directory.
+
+In the above case, the plugin will look for the default prefunded accounts file
+`data/aeplugin_dev_mode/ws1/devmode_prefunded_accounts.json`. During the
+first startup, the file isn't present, so a file is generated using the parameters
+in the plugin config `prefunded:gen`. The generated file contains both public
+and private keys for each account.
+
+In order to make the accounts be created as the genesis block is created,
+a public version of the file is made. The name is the same as the full file,
+except that "-PUB" is added just before the extension. This file contains only
+the public keys and the account, on the format expected by the node.
+
+After first startup, the contents of the `ws1` directory would be:
+
+```
+$ ls data/aeplugin_dev_mode/ws1/
+devmode_prefunded_accounts.json      devmode_prefunded_accounts-PUB.json  mnesia/
+```
+
+**NOTE:** The node will reconstitute and validate the genesis block at each subsequent
+restart, so the prefunded accounts must remain unchanged. If you want to delete and
+re-generate, you will also need to delete the database.
+
+### Default settings
+
 Note that the `config` attribute can be left out. The values in the example
 are the default values, except for `auto_emit_microblocks`, which defaults to `false`.
 
@@ -110,7 +190,9 @@ Note that setting the `network_id` to `ae_dev` activates some defaults in itself
 mainly: the `on_demand` consensus mode.
 
 The parameters `keyblock_interval`, `microblock_interval` and `auto_emit_microblocks`
-are defined in the schema [priv/aeplugin_dev_mode_config_schema.json](priv/aeplugin_dev_mode_config_schema.json). The settings are automatically checked against the schema when the plugin starts.
+are defined in the node schema and handled by the node's built-in dev mode emitter.
+The settings are automatically checked against the schema at node startup, and processed
+by the built-in emitter when `dev_mode` is activated.
 
 Setting the reward delay as low as it will go (`2`), will ensure that rewards
 are paid out sooner, which can be useful to generate funds in the beneficiary

--- a/README.md
+++ b/README.md
@@ -76,8 +76,6 @@ system:
     plugins:
         -
           name: aeplugin_dev_mode
-          config:
-            prefunded_accounts: []
 dev_mode:
     keyblock_interval: 0
     microblock_interval: 0

--- a/examples/devmode.yaml
+++ b/examples/devmode.yaml
@@ -3,8 +3,6 @@ system:
     plugins:
         -
           name: aeplugin_dev_mode
-          config:
-            prefunded_accounts: []
 dev_mode:
     keyblock_interval: 0
     microblock_interval: 0

--- a/priv/aeplugin_dev_mode_config_schema.json
+++ b/priv/aeplugin_dev_mode_config_schema.json
@@ -2,10 +2,25 @@
     "$schema" : "http://json-schema.org/draft-04/schema#",
     "type" : "object",
     "properties" : {
-        "prefunded_accounts" : {
-            "description" : "When not using a synced Chain Database, devmode gives you a set of prefunded accounts",
-            "type" : "array",
-            "default" : []
+        "prefunded" : {
+            "type" : "object",
+	    "additionalProperties" : false,
+            "properties" : {
+                "file" : {
+		    "description" : "Prefunded accounts file (JSON) for loading at chain init time",
+		    "type": "string"
+		},
+                "gen" : {
+		    "description" : "Optional parameters for generating the file, if not present",
+                    "type" : "object",
+		    "additionalProperties" : false,
+                    "properties" : {
+                        "quantity" : { "type" : "integer" },
+                        "balance" : { "type" : "integer" },
+			"mnemonic" : { "type" : "string" }
+                    }
+                }
+            }
         },
         "workspace_path" : {
             "description": "Where to store plugin-specific data",

--- a/src/aeplugin_dev_mode.app.src
+++ b/src/aeplugin_dev_mode.app.src
@@ -4,7 +4,7 @@
   {vsn, "0.1.0"},
   {registered, []},
   {mod, {aeplugin_dev_mode_app, []}},
-  {start_phases, [{check_config, []}]},
+  {start_phases, []},
   {applications, [kernel, stdlib, aecore, ebip39, eaex10, epbkdf2, ec_utils, aedevmode]},
   {env,
    [{'$setup_hooks',

--- a/src/aeplugin_dev_mode_acc_gen.erl
+++ b/src/aeplugin_dev_mode_acc_gen.erl
@@ -3,6 +3,8 @@
         , generate_accounts/2
         , generate_accounts/0]).
 
+-include("aeplugin_dev_mode.hrl").
+
 %% Generates Accounts from sources like mnemonic and seed, utilising ebip39 and eaex10
 %%
 generate_from_mnemonic(Mnemonic, Quantity, Balance) ->
@@ -11,11 +13,10 @@ generate_from_mnemonic(Mnemonic, Quantity, Balance) ->
     format_accounts(Derived, Balance).
 
 generate_accounts() ->
-    generate_accounts(10, 1000000000000000000000).
+    generate_from_mnemonic(mnemonic(), quantity(), balance()).
 
 generate_accounts(Quantity, Balance) ->
-    Mnemonic = ebip39:generate_mnemonic(128),
-    generate_from_mnemonic(Mnemonic, Quantity, Balance).
+    generate_from_mnemonic(mnemonic(), Quantity, Balance).
 
 derive_from_seed(Seed, Quantity) ->
     [ eaex10:derive_aex10_from_seed(Seed, 0, Index) || Index <- lists:seq(1, Quantity) ].
@@ -26,3 +27,14 @@ format_accounts(DerivedKeys, Balance) ->
 format_account_(K, Balance) ->
     AEX10 = eaex10:private_to_public(K),
     (maps:with([priv_key, pub_key], AEX10))#{initial_balance => Balance}.
+
+quantity() -> config(<<"quantity">>, 10).
+balance()  -> config(<<"balance">> , 1000000000000000000000).
+mnemonic() -> config(<<"mnemonic">>, ebip39:generate_mnemonic(128)).
+
+config(Key, Default) ->
+    ok(aeu_plugins:find_config(?PLUGIN_NAME_STR,
+			       [<<"prefunded">>, <<"gen">>, Key],
+			       [user_config, {value, Default}])).
+
+ok({ok, Value}) -> Value.

--- a/src/aeplugin_dev_mode_handler.erl
+++ b/src/aeplugin_dev_mode_handler.erl
@@ -398,7 +398,7 @@ hexlify(Bin) when is_binary(Bin) ->
     << <<(hex(H)),(hex(L))>> || <<H:4,L:4>> <= Bin >>.
 
 hex(C) when C < 10 -> $0 + C;
-    hex(C) -> $a + C - 10.
+hex(C) -> $a + C - 10.
 
 to_bin(B) when is_binary(B) ->
     B;

--- a/src/aeplugin_dev_mode_prefunded.erl
+++ b/src/aeplugin_dev_mode_prefunded.erl
@@ -6,12 +6,18 @@
 -include("aeplugin_dev_mode.hrl").
 
 check_accounts(WorkspaceDir) ->
-    WSName = workspace_name(),
-    Accounts = case read_accounts(WorkspaceDir, WSName) of
-                   {ok, As} ->
+    MnesiaExists = mnesia_db_exists(),
+    Accounts = case read_accounts(WorkspaceDir) of
+                   {ok, Filename, As} ->
+                       lager:info("Read prefunded accounts. Will try auto-creating", []),
+                       suggest_prefunded(Filename, As),
                        As;
+                   {error, _} when not MnesiaExists ->
+                       lager:info("No accounts found, generating..... "),
+                       generate_accounts(WorkspaceDir);
                    {error, _} ->
-                       generate_accounts(WorkspaceDir, WSName)
+                       lager:info("Chain db exists, and no prefunded dev mode accounts", []),
+                       []
                end,
     set_prefunded(Accounts),
     Accounts.
@@ -22,48 +28,52 @@ set_prefunded(Accs) ->
 get_prefunded() ->
     persistent_term:get({?MODULE, prefunded_accounts}, []).
 
-generate_accounts(WorkspacePath, WSName) ->
-    %% A CLI tool will provide a path to a new DB folder or an existing DB
-    %% (maybe for the sake of using some synced node data)
-    %% So here we check whether that DB path already has any accounts data present.
-    %% if not and there is no DB present, it's a new workspace, we generate accounts and 
-    %% set the env var for the node where to look for the accounts. 
-    %% The node later looks for that file if the env var is set and, if present,
-    %% uses it instead of its hardcoded accounts json.
-    %%
-    lager:info("No accounts found, checking for presence of mnesia folder....."),
-    %% check if there is already a mnesia folder present. 
-    %% if so, it's most likely an already existing chain sync and therefore don't generate any accounts.
-    %% if not in a synced dir and no accounts files present, generate new json file.
-    case filelib:is_dir(mnesia_monitor:get_env(dir)) of
-        true -> 
-            lager:info("mnesia folder found on disk, not generating accounts."),
-            [];
-        false ->
-            %% Do generate accounts
-            %% TODO: Add further account creation options here, for now use default acc generating
-            lager:info("No accounts found, generating..... "),
-            case generate_accounts_(WorkspacePath, WSName) of
-                {ok, Filename, Accs} ->
-                    aeu_plugins:suggest_config(prefunded_accs_cfg_key(), Filename),
-                    Accs;
-                error ->
-                    []
-            end
+generate_accounts(WorkspaceDir) ->
+    case generate_accounts_(WorkspaceDir) of
+        {ok, Filename, Accs} ->
+            suggest_prefunded(Filename, Accs),
+            Accs;
+        error ->
+            lager:error("Account generation failed", []),
+            []
     end.
 
-generate_accounts_(WSDir, WSName) ->
+mnesia_db_exists() ->
+    filelib:is_dir(mnesia_monitor:get_env(dir)).
+
+suggest_prefunded(Filename, Accs) ->
+    NodePrefunded = prefunded_pub_name(Filename),
+    ok = generate_node_prefunded(Accs, NodePrefunded),
+    aeu_plugins:suggest_config(prefunded_accs_cfg_key(), NodePrefunded).
+
+prefunded_pub_name(Filename) ->
+    Dir = filename:dirname(Filename),
+    Ext = filename:extension(Filename),
+    Base = filename:basename(Filename, Ext),
+    filename:join(Dir, iolist_to_binary([Base, "-PUB", Ext])).
+
+generate_node_prefunded(Accs, Filename) ->
+    Out = lists:foldl(fun generate_pub_acc/2, #{}, Accs),
+    JSON = jsx:encode(Out),
+    ok = file:write_file(Filename, JSON).
+
+generate_pub_acc(#{pub_key := Pub, initial_balance := Amt}, Acc) ->
+    Key = aeapi:format_account_pubkey(Pub),
+    Acc#{Key => Amt}.
+
+generate_accounts_(WSDir) ->
     try aeplugin_dev_mode_acc_gen:generate_accounts() of
         Accs ->
-            format_generated_accounts(Accs, WSDir, WSName)
+            lager:info("Gen => ~p", [Accs]),
+            format_generated_accounts(Accs, WSDir)
     catch
-        error:E1:ST1 -> 
+        error:E1:ST1 ->
             lager:error("Failed generating devmode accounts: ~p/~p", [E1, ST1]),
             error
     end.
 
-format_generated_accounts(Accs, WSDir, WSName) ->
-    Filename = accounts_file(WSDir, WSName),
+format_generated_accounts(Accs, WSDir) ->
+    Filename = accounts_file(WSDir),
     case format_generated_accounts_(Accs) of
         {ok, JSON} ->
             file:write_file(Filename, JSON),
@@ -73,8 +83,7 @@ format_generated_accounts(Accs, WSDir, WSName) ->
     end.
 
 format_generated_accounts_(Accounts) ->
-    Out = [#{ aeapi:format_account_pubkey(Pub) => Amt} ||
-              #{pub_key := Pub, initial_balance := Amt} <- Accounts],
+    Out = [format_gen_acct(A) || A <- Accounts],
     try jsx:encode(Out) of
         JSON ->
             {ok, JSON}
@@ -84,10 +93,12 @@ format_generated_accounts_(Accounts) ->
             error
     end.
 
-read_accounts(WSDir, WSName) ->
-    {ok, Filename} = aeu_plugins:find_config(?PLUGIN_NAME_STR, [<<"prefunded_accounts_file">>],
-                                             [user_config,
-                                              {value, keyfile_path(WSDir, WSName)}]),
+format_gen_acct(#{pub_key := Pub, priv_key := Priv} = A) ->
+    A#{pub_key := aeapi:format_account_pubkey(Pub),
+       priv_key := encode_priv_key(Priv)}.
+
+read_accounts(WSDir) ->
+    Filename = accounts_file(WSDir),
     read_prefunded_accounts_file(Filename).
 
 read_prefunded_accounts_file(F) ->
@@ -98,12 +109,12 @@ read_prefunded_accounts_file(F) ->
                     %% While jsx is capable of parsing keys to existing atoms,
                     %% We don't need to be so strict about not allowing unknown
                     %% keys in the file. So we explicitly convert what we need.
-                    {ok, [#{ pub_key => Pub
-                           , priv_key => Priv
-                           , initial_balance => Bal} ||
-                             #{ <<"pub_key">> := Pub
-                              , <<"priv_key">> := Priv
-                              , <<"initial_balance">> := Bal} <- Encoded]}
+                    {ok, F, [#{ pub_key => ok(aeapi:decode_account_pubkey(Pub))
+                              , priv_key => decode_priv_key(Priv)
+                              , initial_balance => Bal} ||
+                                #{ <<"pub_key">> := Pub
+                                 , <<"priv_key">> := Priv
+                                 , <<"initial_balance">> := Bal} <- Encoded]}
             catch
                 error:E ->
                     lager:error("Error parsing JSON (~s): ~p", [F, E]),
@@ -114,18 +125,102 @@ read_prefunded_accounts_file(F) ->
             Error
     end.
 
+ok({ok, Value}) -> Value.
+
 prefunded_accs_cfg_key() ->
     [<<"system">>, <<"custom_prefunded_accs_file">>].
 
-workspace_name() ->
-    {ok, Name} = aeu_plugins:find_config(?PLUGIN_NAME_STR, [<<"workspace_name">>],
-                                         [user_config, schema_default]),
-    Name.
+accounts_file(WSDir) ->
+    case aeu_plugins:find_config(?PLUGIN_NAME_STR,
+                                 [<<"prefunded">>, <<"file">>],
+                                 [user_config]) of
+        {ok, Filename} ->
+            case filename:dirname(Filename) of
+                <<".">> ->
+                    filename:join(WSDir, Filename);
+                _ ->
+                    Filename
+            end;
+        undefined ->
+            filename:join(WSDir, "devmode_prefunded_accounts.json")
+    end.
 
-accounts_file(WSPath, WSName) ->
-    Dir = filename:join(WSPath, WSName),
-    filename:join(Dir, "devmode_prefunded_accs_.json").
+%% See PR #19 to https://github.com/aeternity/aeserialization
+%%
+-define(BASE64, 2).
+encode_priv_key(Priv) ->
+    encode(account_secret_key, Priv).
 
-keyfile_path(WSPath, WSName) ->
-    Dir = filename:join(WSPath, WSName),
-    filename:join(Dir, "devmode_acc_keys.json").
+encode(Type, Payload) ->
+    Pfx = type2pfx(Type),
+    Enc = case type2enc(Type) of
+              ?BASE64 -> base64_check(Payload)
+          end,
+    <<Pfx/binary, "_", Enc/binary>>.
+
+decode_priv_key(Bin0) ->
+    Res = case split(Bin0) of
+              [Pfx, Payload] ->
+                  Type = pfx2type(Pfx),
+                  Bin = decode_check(Type, Payload),
+                  case type_size_check(Type, Bin) of
+                      ok -> {Type, Bin};
+                      {error, Reason} -> erlang:error(Reason)
+                  end;
+              _ ->
+                  erlang:error(missing_prefix)
+          end,
+    {account_secret_key, Priv} = Res,
+    Priv.
+
+byte_size_for_type(account_secret_key) -> 32.
+
+type2enc(account_secret_key) -> ?BASE64.
+
+type2pfx(account_secret_key) -> <<"sk">>.
+
+pfx2type(<<"sk">>) -> account_secret_key.
+
+type_size_check(Type, Bin) ->
+    case byte_size_for_type(Type) of
+        not_applicable -> ok;
+        CorrectSize ->
+            Size = byte_size(Bin),
+            case Size =:= CorrectSize of
+                true -> ok;
+                false -> {error, incorrect_size}
+            end
+    end.
+
+base64_check(Bin) ->
+    C = check_str(Bin),
+    binary_to_base64(iolist_to_binary([Bin, C])).
+
+split(Bin) ->
+    binary:split(Bin, [<<"_">>], []).
+
+decode_check(Type, Bin) ->
+    Dec =
+        case type2enc(Type) of
+%%            ?BASE58 -> base58_to_binary(Bin);
+            ?BASE64 -> base64_to_binary(Bin)
+        end,
+    Sz = byte_size(Dec),
+    BSz = Sz - 4,
+    <<Body:BSz/binary, C:4/binary>> = Dec,
+    C = check_str(Body),
+    Body.
+
+check_str(Bin) ->
+    <<C:32/bitstring,_/binary>> =
+        sha256_hash(sha256_hash(Bin)),
+    C.
+
+sha256_hash(Bin) ->
+    crypto:hash(sha256, Bin).
+
+binary_to_base64(Bin) ->
+    base64:encode(Bin).
+
+base64_to_binary(Bin) when is_binary(Bin) ->
+    base64:decode(Bin).

--- a/src/aeplugin_dev_mode_prefunded.erl
+++ b/src/aeplugin_dev_mode_prefunded.erl
@@ -39,7 +39,7 @@ generate_accounts(WorkspaceDir) ->
     end.
 
 mnesia_db_exists() ->
-    filelib:is_dir(mnesia_monitor:get_env(dir)).
+    filelib:is_file(filename:join(mnesia_monitor:get_env(dir), "schema.DAT")).
 
 suggest_prefunded(Filename, Accs) ->
     NodePrefunded = prefunded_pub_name(Filename),


### PR DESCRIPTION
The logic around starting with custom prefunded accounts in dev mode was revisited.
The README has been updated to reflect the new logic, including a simple example on how to
start the node in a separate workspace with separate database and auto-generated accounts.