### PR TITLE
Add info message revealing mnemonic at generation

### DIFF
--- a/src/aeplugin_dev_mode_acc_gen.erl
+++ b/src/aeplugin_dev_mode_acc_gen.erl
@@ -8,6 +8,7 @@
 %% Generates Accounts from sources like mnemonic and seed, utilising ebip39 and eaex10
 %%
 generate_from_mnemonic(Mnemonic, Quantity, Balance) ->
+    lager:info("Mnemonic = ~p", [Mnemonic]),
     Seed = ebip39:mnemonic_to_seed(Mnemonic, <<"">>),
     Derived = derive_from_seed(Seed, Quantity),
     format_accounts(Derived, Balance).


### PR DESCRIPTION
Normally, a mnemonic wouldn't be revealed in system logs, but in the dev mode plugin, it's actually helpful to be ensured that the right mnemonic was actually used for the generation of prefunded accounts.