### PR TITLE
Fix account mounting by changing `data` folder permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,11 @@ RUN cd /aeplugin_dev_mode && rebar3 ae_plugin
 
 FROM aeternity/aeternity:master
 
-COPY --from=pluginbuild /aeplugin_dev_mode/_build/default/aeplugin_dev_mode.ez /home/aeternity/node/plugins/
+COPY --from=pluginbuild /aeplugin_dev_mode/_build/default/aeplugin_dev_mode.ez plugins/
+RUN mkdir -p data/aeplugin_dev_mode
 
 # The priv/ and examples/devmode.yaml need to be copied explicitly
-ADD examples/devmode.yaml /home/aeternity/node/devmode.yaml
+ADD examples/devmode.yaml devmode.yaml
 
 EXPOSE 3313
 


### PR DESCRIPTION
This PR is supported by the Æternity Foundation

The problem it solves: if I'm mounting `devmode_prefunded_accounts.json` as
```yaml
    volumes:
      - ./aeternity.yaml:/home/aeternity/node/devmode.yaml
      - ./accounts.json:/home/aeternity/node/data/aeplugin_dev_mode/devmode_prefunded_accounts.json
```
 then the node fails with `{badmatch,{error,eacces}}` because `data/aeplugin_dev_mode` folder's owner is `root`, so the plugin have no write permission and can't generate accounts in
https://github.com/aeternity/aeplugin_dev_mode/blob/b7af4f371220cf885d8daaa5a5ed4b9326ca823e/src/aeplugin_dev_mode_prefunded.erl#L44-L47
but it works for some reason if I mount accounts as
```yaml
    volumes:
      - ./aeternity.yaml:/home/aeternity/node/devmode.yaml
      - ./accounts.json:/home/aeternity/node/data/aeplugin_dev_mode/devmode_prefunded_accounts.json
      - ./accounts-pub.json:/home/aeternity/node/data/aeplugin_dev_mode/devmode_prefunded_accounts-PUB.json
```
I propose to solve this problem by creating `data/aeplugin_dev_mode` folder as `aeternity` user while building the image.